### PR TITLE
Move player to tower before bringing up the upgrade menu

### DIFF
--- a/Assets/Scripts/AIController.cs
+++ b/Assets/Scripts/AIController.cs
@@ -25,4 +25,9 @@ public class AIController : MonoBehaviour
     {
         _agent.SetDestination(dest);
     }
+
+    public bool IsStopped()
+    {
+        return _agent.isStopped;
+    }
 }

--- a/Assets/Scripts/UI/TowerMenuUISystem.cs
+++ b/Assets/Scripts/UI/TowerMenuUISystem.cs
@@ -9,18 +9,31 @@ public class TowerMenuUISystem : MonoBehaviour, IUISystem
     private CanvasGroup _canvasGroup;
     private GameObject _focusedTower;
     private UIManager _uiManager;
+    private AIController _player;
+
+    private bool _wait = false;
 
 
     void Start()
     {
         // Initialize private fields
         _canvasGroup = GetComponent<CanvasGroup>();
+
+        _player = GameObject.Find("Player").GetComponent<AIController>();
         _uiManager = GameObject.Find("UIManager").GetComponent<UIManager>();
 
         // Hide the canvas group
         _canvasGroup.alpha = 0;
     }
 
+    void Update()
+    {
+        if (_wait && _player.IsStopped())
+        {
+            ShowUpgradeUI();
+            _wait = false;
+        }
+    }
 
     public bool Create(GameObject tower)
     {
@@ -30,7 +43,6 @@ public class TowerMenuUISystem : MonoBehaviour, IUISystem
         }
         else
         {
-            Debug.Log("This is actually a new menu.");
             _focusedTower = tower;
             _canvasGroup.alpha = 1;
             return true;
@@ -55,9 +67,14 @@ public class TowerMenuUISystem : MonoBehaviour, IUISystem
     {
         // TODO: this should fire an event instead. We should not have a reference to the UI manager here.
         Hide();
+        // TODO: Move player to the tower
+        _player.MoveTo(_focusedTower.transform.position);
+        _wait = true;
+    }
 
-        // Move player to the tower.
-
+    private void ShowUpgradeUI()
+    {
+        Debug.Log("Calling the upgrade menu");
         _uiManager.ShowUpgradeMenu(_focusedTower);
     }
 }

--- a/Assets/Scripts/UI/UIManager.cs
+++ b/Assets/Scripts/UI/UIManager.cs
@@ -28,8 +28,6 @@ public class UIManager : MonoBehaviour
         {
             _screenStack.Push(_towerMenuSystem);
         }
-
-        Debug.Log(_screenStack);
     }
 
     public void ShowUpgradeMenu(GameObject tower)


### PR DESCRIPTION
The player now moves towards the tower, but is blocked by the tower and hence cannot
"reach" their destination, therefore, never stops.

**Description:** (Enter a little description of the problem that this PR solves and how)

**Issue:** Fixes #x (replace x with the issue number that this PR solves. If there was no issue, delete this line)

**Steps to test:**
1. How should your PR be tested
1. You should omit trivial steps like "pull this branch"

**Outstanding:**
1. If you think there are some changes that will need to be done after merging this PR, mention them here
1. A PR should not break the build and be stable
1. **DO NOT** open a pull request if you're still working on it and it is not ready for merge. Use a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead
