### PR TITLE
Version bump for VSCode Unity extension

### DIFF
--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -1,9 +1,0 @@
----
-image: restyled/restyler-dotnet-format:v0.0.1-2
-command:
-- dotnet-format-files
-arguments: []
-include:
-- "**/*.cs"
-- "**/*.vb"
-interpreters: []

--- a/Assets/Scripts/InputSystem.cs
+++ b/Assets/Scripts/InputSystem.cs
@@ -9,7 +9,7 @@ public class InputSystem : MonoBehaviour
     private Camera _mainCamera;
     private GameObject _player;
     private UIManager _UIManager;
-    
+
     void Start()
     {
         // Initialize private fields
@@ -24,13 +24,12 @@ public class InputSystem : MonoBehaviour
     void Update()
     {
         // Check left mouse click or selections
-        if (Input.GetButtonDown("Fire1")) 
+        if (Input.GetButtonDown("Fire1"))
         {
-            RaycastHit hit;
-            if (Physics.Raycast(_mainCamera.ScreenPointToRay(Input.mousePosition), out hit)) 
+            if (Physics.Raycast(_mainCamera.ScreenPointToRay(Input.mousePosition), out RaycastHit hit))
             {
                 GameObject hitObject = hit.transform.gameObject;
-                if (hitObject.CompareTag("Tower")) 
+                if (hitObject.CompareTag("Tower"))
                 {
                     // TODO: This should fire an even instead.
                     _UIManager.ShowTowerMenu(hitObject);
@@ -39,17 +38,16 @@ public class InputSystem : MonoBehaviour
         }
 
         // Check right mouse click or movement
-        if (Input.GetButtonDown("Fire2")) 
+        if (Input.GetButtonDown("Fire2"))
         {
-            RaycastHit hit;
-            if (Physics.Raycast(_mainCamera.ScreenPointToRay(Input.mousePosition), out hit)) 
+            if (Physics.Raycast(_mainCamera.ScreenPointToRay(Input.mousePosition), out RaycastHit hit))
             {
                 _player.GetComponent<AIController>().MoveTo(hit.point);
             }
         }
 
         // Check escape button or cancel
-        if (Input.GetButtonDown("Cancel")) 
+        if (Input.GetButtonDown("Cancel"))
         {
             // TODO: This should fire an event instead.
             _UIManager.HideAll();

--- a/Assets/Scripts/UI/IUISystem.cs
+++ b/Assets/Scripts/UI/IUISystem.cs
@@ -12,7 +12,7 @@ public interface IUISystem
     /// <param name="obj"><c>GameObject </c> used to populate the layer</param>
     /// <returns>Boolean. True if repopulated.</returns>
     bool Create(GameObject obj);
-    
+
     /// <summary>
     /// Hides the canvas layer using its alpha value.
     /// </summary>

--- a/Assets/Scripts/UI/UIManager.cs
+++ b/Assets/Scripts/UI/UIManager.cs
@@ -9,9 +9,9 @@ public class UIManager : MonoBehaviour
 {
     private UpgradeMenuUISystem _upgradeMenuSystem;
     private TowerMenuUISystem _towerMenuSystem;
-    
+
     private Stack<IUISystem> _screenStack;
-    
+
 
     void Start()
     {
@@ -39,7 +39,7 @@ public class UIManager : MonoBehaviour
         {
             _screenStack.Push(_upgradeMenuSystem);
         }
-    }    
+    }
 
     /// <summary>
     /// Hide all UI layers in the stack.

--- a/Assets/Scripts/UI/UpgradeMenuUISystem.cs
+++ b/Assets/Scripts/UI/UpgradeMenuUISystem.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using UnityEngine.UI;
 
 
 /// <summary>
@@ -34,7 +35,7 @@ public class UpgradeMenuUISystem : MonoBehaviour, IUISystem
     public bool Create(GameObject tower)
     {
         _focusedTower = tower;
-        setButtonActivation(tower.GetComponent<UpgradeTree>());
+        SetButtonActivation(tower.GetComponent<UpgradeTree>());
         _canvasGroup.alpha = 1;
         return true;
     }
@@ -62,17 +63,17 @@ public class UpgradeMenuUISystem : MonoBehaviour, IUISystem
     public void OnClick(string type)
     {
         switch (type)
-        {  
+        {
             case "green":
-                createNewTower(_greenPrefab);
+                CreateNewTower(_greenPrefab);
                 break;
 
             case "red":
-                createNewTower(_redPrefab);
+                CreateNewTower(_redPrefab);
                 break;
 
             case "gold":
-                createNewTower(_goldPrefab);
+                CreateNewTower(_goldPrefab);
                 break;
 
             default:
@@ -86,7 +87,7 @@ public class UpgradeMenuUISystem : MonoBehaviour, IUISystem
     /// Sets the <c>Interactable </c> property on buttons for upgrades based on the provided <c>UpgradeTree</c>.
     /// <param name="tree"><c>UpgradeTree </c> object to set button activation.</param>
     /// </summary>
-    void setButtonActivation(UpgradeTree tree)
+    void SetButtonActivation(UpgradeTree tree)
     {
         //
     }
@@ -96,7 +97,7 @@ public class UpgradeMenuUISystem : MonoBehaviour, IUISystem
     /// Creates a new tower where the currently focused tower is and then destroys the focused tower.
     /// <param name="newTowerPrefab">Prefab for the new tower to create.</param>
     /// </summary>
-    void createNewTower(GameObject newTowerPrefab)
+    void CreateNewTower(GameObject newTowerPrefab)
     {
         GameObject newTower = Instantiate(newTowerPrefab, _focusedTower.transform.position, _focusedTower.transform.rotation);
         GameObject.Destroy(_focusedTower);

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "com.unity.collab-proxy": "1.2.16",
     "com.unity.ide.rider": "1.1.4",
-    "com.unity.ide.vscode": "1.1.4",
+    "com.unity.ide.vscode": "1.2.0",
     "com.unity.test-framework": "1.1.11",
     "com.unity.textmeshpro": "2.0.1",
     "com.unity.timeline": "1.2.10",


### PR DESCRIPTION
**Description:** VS Code plugin for Unity version 1.1.4 had a [bug](https://issuetracker.unity3d.com/issues/vscode-omnisharp-project-reference-warnings-are-thrown-in-vscode-console-when-using-vscode-1-dot-1-4-1) that misbehaved with OmniSharp. Upgraded it to version 1.2.0 and ran autoformat on code to test.

**Steps to test:**
1. Open the project in VS Code
1. Get better formatting suggestions and no OmniSharp warnings