### PR TITLE
Add the move button to tower menu

### DIFF
--- a/Assets/Prefabs/Towers/BaseTower.prefab
+++ b/Assets/Prefabs/Towers/BaseTower.prefab
@@ -61,7 +61,7 @@ GameObject:
   - component: {fileID: 311745129957277617}
   m_Layer: 0
   m_Name: Cube
-  m_TagString: Tower
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/UI/TowerMenuUI.prefab
+++ b/Assets/Prefabs/UI/TowerMenuUI.prefab
@@ -90,7 +90,7 @@ GameObject:
   - component: {fileID: 2688080685297590437}
   - component: {fileID: 2688080685297590436}
   m_Layer: 5
-  m_Name: Button
+  m_Name: Upgrade
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -228,6 +228,7 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 2688080685297590435}
+  - {fileID: 550014614163714030}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -320,3 +321,198 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5fc3f86f9aa278c4fa37b266aa3ea2cc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &3183591882600194723
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 812564247894500604}
+  - component: {fileID: 504955017314330896}
+  - component: {fileID: 1125478159022005671}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &812564247894500604
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3183591882600194723}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 550014614163714030}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &504955017314330896
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3183591882600194723}
+  m_CullTransparentMesh: 0
+--- !u!114 &1125478159022005671
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3183591882600194723}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Move
+--- !u!1 &4047114067454862062
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 550014614163714030}
+  - component: {fileID: 5451012681161346543}
+  - component: {fileID: 696787302624890264}
+  - component: {fileID: 5489306830225390053}
+  m_Layer: 5
+  m_Name: Move
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &550014614163714030
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4047114067454862062}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 812564247894500604}
+  m_Father: {fileID: 2688080686154301273}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 369.5, y: 185}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5451012681161346543
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4047114067454862062}
+  m_CullTransparentMesh: 0
+--- !u!114 &696787302624890264
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4047114067454862062}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &5489306830225390053
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4047114067454862062}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 696787302624890264}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -183,6 +183,18 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5694667101778985782, guid: 284a761a17c45ee44b3075c871a586a1,
+        type: 3}
+      propertyPath: Selector
+      value: 
+      objectReference: {fileID: 603636180280687057, guid: 633f7d526c4f0f84abe3e2240b725934,
+        type: 3}
+    - target: {fileID: 5694667101778985782, guid: 284a761a17c45ee44b3075c871a586a1,
+        type: 3}
+      propertyPath: BaseTower
+      value: 
+      objectReference: {fileID: 379762198253035637, guid: c3f33bd9d6e48cf43a6c01ebb8060a3f,
+        type: 3}
     - target: {fileID: 5694667101778985783, guid: 284a761a17c45ee44b3075c871a586a1,
         type: 3}
       propertyPath: m_Name
@@ -231,6 +243,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1111380771}
+  - component: {fileID: 1111380772}
   m_Layer: 0
   m_Name: GameManager
   m_TagString: Untagged
@@ -252,6 +265,20 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1111380772
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1111380770}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dd56f57aa650f8243952c4c8f86dabf5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  SelectorPrefab: {fileID: 603636180280687057, guid: 633f7d526c4f0f84abe3e2240b725934,
+    type: 3}
 --- !u!114 &1199413780 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1608300310646589192, guid: f8da79642fd4d444586ede966e9b02bf,
@@ -737,7 +764,7 @@ PrefabInstance:
     - target: {fileID: 1101803320110623002, guid: f8da79642fd4d444586ede966e9b02bf,
         type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: OnClick
+      value: OnUpgradeClick
       objectReference: {fileID: 0}
     - target: {fileID: 1101803320110623002, guid: f8da79642fd4d444586ede966e9b02bf,
         type: 3}
@@ -839,6 +866,36 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: UIManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 7361819782494023771, guid: f8da79642fd4d444586ede966e9b02bf,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7361819782494023771, guid: f8da79642fd4d444586ede966e9b02bf,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7361819782494023771, guid: f8da79642fd4d444586ede966e9b02bf,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7361819782494023771, guid: f8da79642fd4d444586ede966e9b02bf,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1579299771}
+    - target: {fileID: 7361819782494023771, guid: f8da79642fd4d444586ede966e9b02bf,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: OnMoveClick
+      objectReference: {fileID: 0}
+    - target: {fileID: 7361819782494023771, guid: f8da79642fd4d444586ede966e9b02bf,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 7472637742087252931, guid: f8da79642fd4d444586ede966e9b02bf,
         type: 3}

--- a/Assets/Scripts/Events/TestEventCall.cs
+++ b/Assets/Scripts/Events/TestEventCall.cs
@@ -5,10 +5,10 @@ using UnityEngine;
 /// </summary>
 public class TestEventCall : MonoBehaviour
 {
-    private TDEvent<string, int> a = new TDEvent<string, int>();
+    private TDEvent<string, int> a;
     void Start()
     {
-        EventRegistry.RegisterEvent("test", a);
+        a = EventRegistry.GetEvent<string, int>("test");
     }
 
     void Update()

--- a/Assets/Scripts/InputSystem.cs
+++ b/Assets/Scripts/InputSystem.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using UnityEngine.Events;
 
 
 /// <summary>
@@ -7,11 +8,9 @@
 public class InputSystem : MonoBehaviour
 {
     // TODO: Have a single utils class for doing these raycasts
-    public GameObject selector;
+    public GameObject BaseTower;
 
-    private bool placer = false;
     private GameObject player;
-    private GameObject selectorInstance;
     private Camera mainCamera;
     private UIManager uiManager;
 
@@ -33,11 +32,10 @@ public class InputSystem : MonoBehaviour
         {
             if (Physics.Raycast(mainCamera.ScreenPointToRay(Input.mousePosition), out RaycastHit hit))
             {
-                GameObject hitObject = hit.transform.gameObject;
+                GameObject hitObject = hit.transform.parent.gameObject;
                 if (hitObject.CompareTag("Tower"))
                 {
                     // TODO: This should fire an even instead.
-                    // TODO: This actually sends in the "cube" now and not the empty root. Maybe add the collider to the root? Or get the parent and then pass that here 
                     uiManager.ShowTowerMenu(hitObject);
                 }
             }
@@ -62,23 +60,8 @@ public class InputSystem : MonoBehaviour
         // Check the X button or "place", toggle the selector
         if (Input.GetKeyDown(KeyCode.X))
         {
-            switch (placer)
-            {
-                case true:
-                    {
-                        Destroy(selectorInstance);
-                        placer = false;
-                    }
-                    break;
-
-                case false:
-                    {
-                        Physics.Raycast(mainCamera.ScreenPointToRay(Input.mousePosition), out RaycastHit hit, LayerMask.GetMask("Ground"));
-                        selectorInstance = Instantiate(selector, hit.point, Quaternion.identity);
-                        placer = true;
-                    }
-                    break;
-            }
+            Physics.Raycast(mainCamera.ScreenPointToRay(Input.mousePosition), out RaycastHit hit, LayerMask.GetMask("Ground"));
+            EventRegistry.Invoke("togglePlacer", BaseTower, hit.point);
         }
     }
 }

--- a/Assets/Scripts/Towers/TowerPlacementSystem.cs
+++ b/Assets/Scripts/Towers/TowerPlacementSystem.cs
@@ -1,0 +1,50 @@
+using UnityEngine;
+
+public class TowerPlacementSystem : MonoBehaviour
+{
+    public GameObject SelectorPrefab;
+    private GameObject instance;
+    private GameObject focus;
+    private bool isActive = false;
+
+    void Start()
+    {
+        EventRegistry.RegisterAction<GameObject, Vector3>("togglePlacer", TogglePlacer);
+    }
+
+    void Update()
+    {
+        if (isActive && Input.GetButtonDown("Fire1"))
+        {
+            if (instance.GetComponent<TowerPlacer>().PlaceTower())
+            {
+                DestroyPlacer();
+            }
+        }
+    }
+
+    public void TogglePlacer(GameObject targetTower, Vector3 location)
+    {
+        if (isActive)
+        {
+            DestroyPlacer();
+        }
+        else
+        {
+            CreatePlacer(targetTower, location);
+        }
+    }
+
+    private void CreatePlacer(GameObject targetTower, Vector3 location)
+    {
+        instance = Instantiate(SelectorPrefab, location, Quaternion.identity);
+        instance.GetComponent<TowerPlacer>().SetTower(targetTower);
+        isActive = true;
+    }
+
+    private void DestroyPlacer()
+    {
+        Destroy(instance);
+        isActive = false;
+    }
+}

--- a/Assets/Scripts/Towers/TowerPlacementSystem.cs.meta
+++ b/Assets/Scripts/Towers/TowerPlacementSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dd56f57aa650f8243952c4c8f86dabf5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Towers/TowerPlacer.cs
+++ b/Assets/Scripts/Towers/TowerPlacer.cs
@@ -7,14 +7,33 @@
 public class TowerPlacer : MonoBehaviour
 {
     /// <summary>
-    /// A reference to the base tower prefab that is to be placed
+    /// A reference to the tower prefab that is to be placed
     /// </summary>
-    public GameObject BaseTower;
+    public GameObject TowerObject;
 
     private bool blocked = false;
     private readonly Color green = new Color(0, 1, 0, 0.3f);
     private readonly Color red = new Color(1, 0, 0, 0.3f);
     private new Renderer renderer;
+
+    public void SetTower(GameObject reference)
+    {
+        TowerObject = reference;
+    }
+
+    public bool PlaceTower()
+    {
+        if (!blocked)
+        {
+            Instantiate(TowerObject, transform.position, transform.rotation);
+            Destroy(TowerObject);
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
 
     void Start()
     {
@@ -29,12 +48,6 @@ public class TowerPlacer : MonoBehaviour
             // TODO: Interpolate values instead of directly setting them for a smoother experience
             float oldY = transform.position.y;
             transform.position = new Vector3(hit.point.x, oldY, hit.point.z);
-        }
-
-        // TODO: This should be done by receiving an event fired from the InputSystem
-        if (Input.GetButtonDown("Fire1") && !blocked)
-        {
-            Instantiate(BaseTower, transform.position, transform.rotation);
         }
     }
 

--- a/Assets/Scripts/UI/TowerMenuUISystem.cs
+++ b/Assets/Scripts/UI/TowerMenuUISystem.cs
@@ -48,7 +48,7 @@ public class TowerMenuUISystem : MonoBehaviour, IUISystem
     /// <summary>
     /// Callback for the upgrade button.
     /// </summary>
-    public void OnClick()
+    public void OnUpgradeClick()
     {
         // TODO: this should fire an event instead. We should not have a reference to the UI manager here.
         Hide();
@@ -56,5 +56,16 @@ public class TowerMenuUISystem : MonoBehaviour, IUISystem
         // Move player to the tower.
 
         uiManager.ShowUpgradeMenu(focusedTower);
+    }
+
+    /// <summary>
+    /// Callback for the Move button
+    /// </summary>
+    public void OnMoveClick()
+    {
+        Hide();
+        Vector3 spawnLocation = focusedTower.transform.position;
+        spawnLocation.y = 0;
+        EventRegistry.Invoke("togglePlacer", focusedTower, spawnLocation);
     }
 }


### PR DESCRIPTION
**Description:** Adds the ability to move a tower to the tower menu. Also makes some improvements to the event system.

**Steps to test:**
1. Click on a tower
1. Click on the move button
1. The placer should come up. If you click to place, the previous instance of that tower will be destroyed
