### PR TITLE
change detection to raycast

### DIFF
--- a/Assets/Prefabs/Enemy.prefab
+++ b/Assets/Prefabs/Enemy.prefab
@@ -15,7 +15,7 @@ GameObject:
   - component: {fileID: 7304521332059732314}
   - component: {fileID: 5141389758979643607}
   - component: {fileID: 362618370743414663}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: Enemy
   m_TagString: Enemy
   m_Icon: {fileID: 0}
@@ -31,7 +31,7 @@ Transform:
   m_GameObject: {fileID: 7304521332059732316}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.3311078, y: 0.29932, z: 0.3311078}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 8960267717484967156}
   m_Father: {fileID: 0}
@@ -95,7 +95,7 @@ CapsuleCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   m_Radius: 0.5000001
-  m_Height: 2
+  m_Height: 2.5
   m_Direction: 1
   m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
 --- !u!195 &7304521332059732314
@@ -160,6 +160,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_TagString
       value: Untagged
+      objectReference: {fileID: 0}
+    - target: {fileID: 642114022979103222, guid: 5bf47b8968d95cf46a88b9b871244b15,
+        type: 3}
+      propertyPath: m_Layer
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 2158106795149971263, guid: 5bf47b8968d95cf46a88b9b871244b15,
+        type: 3}
+      propertyPath: m_Layer
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 6341978705165544364, guid: 5bf47b8968d95cf46a88b9b871244b15,
         type: 3}
@@ -265,6 +275,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6387999403585348765, guid: 5bf47b8968d95cf46a88b9b871244b15,
+        type: 3}
+      propertyPath: m_Layer
+      value: 11
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5bf47b8968d95cf46a88b9b871244b15, type: 3}

--- a/Assets/Prefabs/Towers/BaseTower.prefab
+++ b/Assets/Prefabs/Towers/BaseTower.prefab
@@ -78,6 +78,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4c3f415b9bad6246893ee1e6c79d66a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  extremeAngle: 60
+  noOfRays: 120
 --- !u!135 &8947906116660353105
 SphereCollider:
   m_ObjectHideFlags: 0
@@ -87,7 +89,7 @@ SphereCollider:
   m_GameObject: {fileID: 379762198253035637}
   m_Material: {fileID: 0}
   m_IsTrigger: 1
-  m_Enabled: 1
+  m_Enabled: 0
   serializedVersion: 2
   m_Radius: 7
   m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/Scenes/BattleSimulationScene.unity
+++ b/Assets/Scenes/BattleSimulationScene.unity
@@ -215,6 +215,75 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &379618293
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 7304521332059732294, guid: d4734eb4b28571d44bf71896b9ea8c56,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.66
+      objectReference: {fileID: 0}
+    - target: {fileID: 7304521332059732294, guid: d4734eb4b28571d44bf71896b9ea8c56,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7304521332059732294, guid: d4734eb4b28571d44bf71896b9ea8c56,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -5.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 7304521332059732294, guid: d4734eb4b28571d44bf71896b9ea8c56,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7304521332059732294, guid: d4734eb4b28571d44bf71896b9ea8c56,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7304521332059732294, guid: d4734eb4b28571d44bf71896b9ea8c56,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7304521332059732294, guid: d4734eb4b28571d44bf71896b9ea8c56,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7304521332059732294, guid: d4734eb4b28571d44bf71896b9ea8c56,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 7304521332059732294, guid: d4734eb4b28571d44bf71896b9ea8c56,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7304521332059732294, guid: d4734eb4b28571d44bf71896b9ea8c56,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7304521332059732294, guid: d4734eb4b28571d44bf71896b9ea8c56,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7304521332059732316, guid: d4734eb4b28571d44bf71896b9ea8c56,
+        type: 3}
+      propertyPath: m_Name
+      value: Enemy
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d4734eb4b28571d44bf71896b9ea8c56, type: 3}
 --- !u!1 &701554287
 GameObject:
   m_ObjectHideFlags: 0
@@ -457,6 +526,21 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7304521332059732294, guid: dcc3216c7ba1df143b641f566abe358b,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7304521332059732294, guid: dcc3216c7ba1df143b641f566abe358b,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7304521332059732294, guid: dcc3216c7ba1df143b641f566abe358b,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 7304521332059732316, guid: dcc3216c7ba1df143b641f566abe358b,
         type: 3}
       propertyPath: m_Name
@@ -466,6 +550,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_TagString
       value: Enemy
+      objectReference: {fileID: 0}
+    - target: {fileID: 7304521332059732316, guid: dcc3216c7ba1df143b641f566abe358b,
+        type: 3}
+      propertyPath: m_Layer
+      value: 11
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: dcc3216c7ba1df143b641f566abe358b, type: 3}
@@ -647,10 +736,25 @@ PrefabInstance:
       propertyPath: m_TagString
       value: Tower
       objectReference: {fileID: 0}
+    - target: {fileID: 427160180144582454, guid: c3f33bd9d6e48cf43a6c01ebb8060a3f,
+        type: 3}
+      propertyPath: extremeAngle
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 427160180144582454, guid: c3f33bd9d6e48cf43a6c01ebb8060a3f,
+        type: 3}
+      propertyPath: noOfRays
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 809808391455027423, guid: c3f33bd9d6e48cf43a6c01ebb8060a3f,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3362462000056208341, guid: c3f33bd9d6e48cf43a6c01ebb8060a3f,
         type: 3}
       propertyPath: Range
-      value: 5
+      value: 7.5
       objectReference: {fileID: 0}
     - target: {fileID: 7252183657876614786, guid: c3f33bd9d6e48cf43a6c01ebb8060a3f,
         type: 3}
@@ -726,6 +830,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Radius
       value: 2.92
+      objectReference: {fileID: 0}
+    - target: {fileID: 8947906116660353105, guid: c3f33bd9d6e48cf43a6c01ebb8060a3f,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c3f33bd9d6e48cf43a6c01ebb8060a3f, type: 3}

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -131,12 +131,12 @@ PrefabInstance:
     - target: {fileID: 7304521332059732294, guid: d4734eb4b28571d44bf71896b9ea8c56,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 7.174108
+      value: 7.29
       objectReference: {fileID: 0}
     - target: {fileID: 7304521332059732294, guid: d4734eb4b28571d44bf71896b9ea8c56,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.29932
+      value: 1.25
       objectReference: {fileID: 0}
     - target: {fileID: 7304521332059732294, guid: d4734eb4b28571d44bf71896b9ea8c56,
         type: 3}
@@ -370,12 +370,12 @@ PrefabInstance:
     - target: {fileID: 7304521332059732294, guid: d4734eb4b28571d44bf71896b9ea8c56,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 6.6982784
+      value: 6.827
       objectReference: {fileID: 0}
     - target: {fileID: 7304521332059732294, guid: d4734eb4b28571d44bf71896b9ea8c56,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.29932
+      value: 1.278
       objectReference: {fileID: 0}
     - target: {fileID: 7304521332059732294, guid: d4734eb4b28571d44bf71896b9ea8c56,
         type: 3}
@@ -427,7 +427,8 @@ PrefabInstance:
       propertyPath: m_Name
       value: Enemy
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 7755894246054718344, guid: d4734eb4b28571d44bf71896b9ea8c56, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: d4734eb4b28571d44bf71896b9ea8c56, type: 3}
 --- !u!1 &1337933908
 GameObject:
@@ -734,7 +735,7 @@ MeshCollider:
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_Enabled: 1
-  serializedVersion: 3
+  serializedVersion: 4
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
@@ -1124,6 +1125,11 @@ PrefabInstance:
       propertyPath: m_Height
       value: 3
       objectReference: {fileID: 0}
+    - target: {fileID: 809808391455027423, guid: c3f33bd9d6e48cf43a6c01ebb8060a3f,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 1901400889486658680, guid: c3f33bd9d6e48cf43a6c01ebb8060a3f,
         type: 3}
       propertyPath: m_Layer
@@ -1197,7 +1203,7 @@ PrefabInstance:
     - target: {fileID: 7873187413585461513, guid: c3f33bd9d6e48cf43a6c01ebb8060a3f,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7873187413585461513, guid: c3f33bd9d6e48cf43a6c01ebb8060a3f,
         type: 3}
@@ -1207,7 +1213,7 @@ PrefabInstance:
     - target: {fileID: 7873187413585461513, guid: c3f33bd9d6e48cf43a6c01ebb8060a3f,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7873187413585461513, guid: c3f33bd9d6e48cf43a6c01ebb8060a3f,
         type: 3}
@@ -1222,7 +1228,7 @@ PrefabInstance:
     - target: {fileID: 7873187413585461513, guid: c3f33bd9d6e48cf43a6c01ebb8060a3f,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
+      value: 180
       objectReference: {fileID: 0}
     - target: {fileID: 7873187413585461513, guid: c3f33bd9d6e48cf43a6c01ebb8060a3f,
         type: 3}
@@ -1237,7 +1243,7 @@ PrefabInstance:
     - target: {fileID: 8947906116660353105, guid: c3f33bd9d6e48cf43a6c01ebb8060a3f,
         type: 3}
       propertyPath: m_Enabled
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c3f33bd9d6e48cf43a6c01ebb8060a3f, type: 3}

--- a/Assets/Scripts/Common/Detection.cs
+++ b/Assets/Scripts/Common/Detection.cs
@@ -6,28 +6,28 @@ public class Detection : MonoBehaviour
     private GameObject target;
     private bool shouldRotate = false;
 
+    float detectionRange;
+
+    Vector3 lookDirection;
+
+    bool isOccupied = false;
+    public float extremeAngle;
+
+    public float noOfRays;
+
+    float deltaAngle;
+    float angleMade = 0f;
+
+    int sweepDirection = +1;
+
     void Start()
     {
         battle = GetComponent<AbstractBattle>();
+        detectionRange = GetComponent<TowerBattle>().Range;
+        lookDirection = -transform.forward;
+        deltaAngle = (2 * extremeAngle) / noOfRays;
     }
-
-    void OnTriggerEnter(Collider other)
-    {
-        if (other.gameObject.tag == "Enemy")
-        {
-            target = other.gameObject;
-            shouldRotate = true;
-            battle?.OnDetect(target);
-        }
-    }
-
-    void OnTriggerExit(Collider other)
-    {
-        shouldRotate = false;
-        battle?.OnLose();
-    }
-
-    void Update()
+    void FixedUpdate()
     {
         if (shouldRotate && target != null)
         {
@@ -37,5 +37,46 @@ public class Detection : MonoBehaviour
             Quaternion targetRotation = Quaternion.LookRotation(look);
             transform.rotation = Quaternion.Lerp(transform.rotation, targetRotation, 0.1f);
         }
+        if (!isOccupied)
+        {
+            Debug.DrawRay(transform.position, lookDirection * detectionRange, Color.white, 0.2f);
+            if (Physics.Raycast(transform.position, lookDirection, out RaycastHit hit, detectionRange, LayerMask.GetMask("Enemy")))
+            {
+                Debug.DrawLine(transform.position, hit.transform.position, Color.black, 2f);
+                Debug.Log("Found " + hit.transform.gameObject.name);
+                Detected(hit.transform.gameObject);
+            }
+            lookDirection = Quaternion.Euler(0, deltaAngle * sweepDirection, 0) * lookDirection;
+            angleMade += deltaAngle * sweepDirection;
+            if (Mathf.Approximately(angleMade, extremeAngle * sweepDirection))
+            {
+                sweepDirection *= -1;
+            }
+        }
+        else
+        {
+            if (target == null || Vector3.Distance(target.transform.position, transform.position) > detectionRange)
+            {
+                battle?.OnLose();
+            }
+        }
+    }
+
+    void Detected(GameObject enemy)
+    {
+        isOccupied = true;
+        shouldRotate = true;
+        target = enemy;
+        battle?.OnDetect(target);
+    }
+
+    public void Reset()
+    {
+        isOccupied = false;
+        shouldRotate = false;
+        lookDirection = -transform.forward;
+        angleMade = 0f;
+        sweepDirection = +1;
+        target = null;
     }
 }

--- a/Assets/Scripts/Towers/TowerBattle.cs
+++ b/Assets/Scripts/Towers/TowerBattle.cs
@@ -25,6 +25,7 @@ public class TowerBattle : AbstractBattle
     {
         isFighting = false;
         target = null;
+        GetComponent<Detection>().Reset();
     }
 
     void Update()

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2019.3.2f1
-m_EditorVersionWithRevision: 2019.3.2f1 (c46a3a38511e)
+m_EditorVersion: 2019.3.9f1
+m_EditorVersionWithRevision: 2019.3.9f1 (e6e740a1c473)


### PR DESCRIPTION
**Description:** Detection no longer takes place based on Triggers but based on raycasting(like a radar)

**Issue:** Fixes #63 

**Steps to test:**
1. Play in the main Scene to check(gizmos turned on in Game windows to see the rays)

**Outstanding:**
1.Added an enemy layer which should be the layer of enemies
1. For detection ,the towers now have input fields i.e. Extreme Angle and Total Rays
 - Extreme angle gives field of view(90 means 180 degrees of view(2*extreme angle))
 - Total rays gives more precision (more no. rays for a set angle,more accuracy but less speed)
 -  the detection range should is same as range in battle component

2.Increased the size of enemy for better detection and increased the height of its capsule collider to fix the initial problem(the raycasting is at ground level and could not detect the enemy)
3.The sphere collider on the base tower can now be turned off. 
