### PR TITLE
nearest enemy detection implemented with tests

### DIFF
--- a/Assets/Scripts/Towers/RangedTowerBattle.cs
+++ b/Assets/Scripts/Towers/RangedTowerBattle.cs
@@ -9,11 +9,26 @@ public class RangedTowerBattle : AbstractBattle
     private bool isFighting = false;
     private bool turn = false;
     private float timer;
-
+    private float minDistance;
+    private GameObject nearestTarget;
+    
     override public void OnDetect(GameObject[] targets)
     {
         // TODO: Select the closest target instead of the first
-        target = targets[0];
+       nearestTarget = targets[0];
+        minDistance = (nearestTarget.transform.position - transform.position).magnitude;
+       
+        foreach (GameObject targeti in targets) {
+            if ((targeti.transform.position - transform.position).magnitude <= minDistance){
+                minDistance = (targeti.transform.position - transform.position).magnitude;
+                nearestTarget = targeti; 
+
+            } 
+            
+        }
+
+     
+        target = nearestTarget;
         isFighting = true;
         turn = true;
         timer = 0f;
@@ -29,6 +44,7 @@ public class RangedTowerBattle : AbstractBattle
 
     void Update()
     {
+        
         if (target == null)
         {
             OnLose();

--- a/Assets/Tests/PlayMode/Gameplay/BattleTests.cs
+++ b/Assets/Tests/PlayMode/Gameplay/BattleTests.cs
@@ -3,12 +3,13 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 using UnityEngine.SceneManagement;
+using System.Collections.Generic;
 
 namespace Tests.Gameplay
 {
 
     // TODO: FIX
-    public class BattleTests
+    public class BattleTests : MonoBehaviour
     {
         [SetUp]
         public void SetUp()
@@ -25,10 +26,28 @@ namespace Tests.Gameplay
             tower.GetComponent<AbstractBattle>().OnDetect(new[] {enemy});
 
             float health = enemy.GetComponent<Damageable>().GetHealth();
-            yield return new WaitForSeconds(0.5f);
+            yield return new WaitForSeconds(1.0f);
             Assert.AreNotEqual(health, enemy.GetComponent<Damageable>().GetHealth());
         }
-
+        [UnityTest]
+        public IEnumerator TowerAttacksNearestEnemy() {
+            GameObject tower = GameObject.FindWithTag("Tower");
+            GameObject enemy1 = GameObject.FindWithTag("Enemy");
+            tower.GetComponent<AbstractBattle>().FireRate = 0.25f;
+            float distance = tower.GetComponent<AbstractBattle>().Range;
+            GameObject enemy2 = Instantiate(enemy1, tower.transform.position + new Vector3(distance / 3, 0, distance / 3) , Quaternion.identity);
+            enemy1.transform.position = tower.transform.position + new Vector3(distance/2 , 0, distance/2); // Both enemies are in attackin range
+            GameObject[] targets = new GameObject[2];
+            targets[0]=enemy1;   
+            targets[1]=enemy2;
+            tower.GetComponent<AbstractBattle>().OnDetect(targets);
+            float health1 = enemy1.GetComponent<Damageable>().GetHealth();
+            float health2 = enemy2.GetComponent<Damageable>().GetHealth();
+            yield return new WaitForSeconds(0.5f);
+            Assert.AreNotEqual(health2, enemy2.GetComponent<Damageable>().GetHealth());
+            Assert.AreEqual(health1, enemy1.GetComponent<Damageable>().GetHealth());
+            
+        }
         [UnityTest]
         public IEnumerator TowerRevertsToIdleOnTargetLose()
         {


### PR DESCRIPTION
**Description:** (changed OnDetect() method to enable tower to detect nearest enemy and attack on it and added test to check it)

**Issue:** Fixes #76  #81 (fixed the TowerAttackEnemies() in battletest.cs by changing waiting time to 1.0f (for less than 1.0f test not passed))

**Steps to test:**
1. Added test  TowerAttacksNearestEnemy() to check near enemy detection.

