### PR TITLE
add tower movement cost

### DIFF
--- a/Assets/Prefabs/Towers/BaseTower.prefab
+++ b/Assets/Prefabs/Towers/BaseTower.prefab
@@ -15,6 +15,7 @@ GameObject:
   - component: {fileID: 3788306455569853734}
   - component: {fileID: 8912293669541112376}
   - component: {fileID: 904232128615981435}
+  - component: {fileID: 324451367070364092}
   m_Layer: 9
   m_Name: BaseTower
   m_TagString: Tower
@@ -125,6 +126,19 @@ MonoBehaviour:
   Defense: 0.3
   Range: 7
   FireRate: 1
+--- !u!114 &324451367070364092
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 379762198253035637}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ba29a94db3afe28449b5e183d4d13cab, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Type: 0
 --- !u!1001 &4811420638879836389
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Towers/GreenTower.prefab
+++ b/Assets/Prefabs/Towers/GreenTower.prefab
@@ -12,6 +12,11 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 1d7c833c0b3816743aaf7421e10b23c6, type: 2}
+    - target: {fileID: 324451367070364092, guid: c3f33bd9d6e48cf43a6c01ebb8060a3f,
+        type: 3}
+      propertyPath: Type
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 379762198253035637, guid: c3f33bd9d6e48cf43a6c01ebb8060a3f,
         type: 3}
       propertyPath: m_Name

--- a/Assets/Prefabs/Towers/MineTower.prefab
+++ b/Assets/Prefabs/Towers/MineTower.prefab
@@ -28,6 +28,11 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 63e1528cd9212c1489e5afe17957bdab, type: 2}
+    - target: {fileID: 324451367070364092, guid: c3f33bd9d6e48cf43a6c01ebb8060a3f,
+        type: 3}
+      propertyPath: Type
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 379762198253035637, guid: c3f33bd9d6e48cf43a6c01ebb8060a3f,
         type: 3}
       propertyPath: m_Name

--- a/Assets/Prefabs/Towers/RedTower.prefab
+++ b/Assets/Prefabs/Towers/RedTower.prefab
@@ -12,6 +12,11 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 1a8db523250ae4e43bb7330e7ae5df77, type: 2}
+    - target: {fileID: 324451367070364092, guid: c3f33bd9d6e48cf43a6c01ebb8060a3f,
+        type: 3}
+      propertyPath: Type
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 379762198253035637, guid: c3f33bd9d6e48cf43a6c01ebb8060a3f,
         type: 3}
       propertyPath: m_Name

--- a/Assets/Scripts/Data/ETowerType.cs
+++ b/Assets/Scripts/Data/ETowerType.cs
@@ -92,4 +92,29 @@ static class ETowerTypeUtils
                 }
         }
     }
+
+    /// <summary>
+    /// Get the cost for moving the tower.
+    /// </summary>
+    /// <param name="type">The type of tower to move.</param>
+    /// <returns>Integer cost for the movement of that tower.</returns>
+    public static int GetMoveCost(this ETowerType type)
+    {
+        switch (type)
+        {
+            case ETowerType.Base:
+                return 50;
+            case ETowerType.Gold:
+                return 75;
+            case ETowerType.Green:
+                return 75;
+            case ETowerType.Red:
+                return 100;
+            default:
+                {
+                    Debug.LogError("Invalid tower type: " + type);
+                    return 0;
+                }
+        }
+    }
 }

--- a/Assets/Scripts/Towers/TowerPlacementSystem.cs
+++ b/Assets/Scripts/Towers/TowerPlacementSystem.cs
@@ -14,6 +14,8 @@ public class TowerPlacementSystem : MonoBehaviour
     private GameObject focus;
     private bool isActive = false;
 
+    private bool isChecking = false;
+
     void Start()
     {
         EventRegistry.RegisterAction<GameObject, Vector3, bool>("togglePlacer", TogglePlacer);
@@ -21,13 +23,25 @@ public class TowerPlacementSystem : MonoBehaviour
 
     void Update()
     {
-        if (isActive && Input.GetButtonDown("Fire1"))
+        if (isChecking)
         {
-            if (instance.GetComponent<TowerPlacer>().PlaceTower())
+            if (isActive && instance.GetComponent<TowerPlacer>().CheckTransaction())
             {
+                isChecking = false;
                 DestroyPlacer();
             }
         }
+        else
+        {
+            if (isActive && Input.GetButtonDown("Fire1"))
+            {
+                if (instance.GetComponent<TowerPlacer>().PlaceTower())
+                {
+                    isChecking = true;
+                }
+            }
+        }
+
     }
 
     /// <summary>
@@ -54,6 +68,7 @@ public class TowerPlacementSystem : MonoBehaviour
         instance = Instantiate(PlacerPrefab, location, Quaternion.identity);
         instance.GetComponent<TowerPlacer>().SetTower(targetTower, isMove);
         isActive = true;
+        isChecking = false;
     }
 
     private void DestroyPlacer()

--- a/Assets/Tests/PlayMode/UI/TowerUIMenuTests.cs
+++ b/Assets/Tests/PlayMode/UI/TowerUIMenuTests.cs
@@ -53,12 +53,12 @@ namespace Tests.UI
             GameObject baseTower = GameObject.Find("BaseTower");
             EventRegistry.Invoke("showMenu", baseTower, typeof(TowerMenuUISystem));
             GameObject towerMenu = GameObject.Find("TowerMenuUI");
-
             // Bring up the move tool
             towerMenu.GetComponent<TowerMenuUISystem>().OnMoveClick();
             GameObject indicator = GameObject.Find("PlacementIndicator(Clone)");
-            bool check = indicator.GetComponent<TowerPlacer>().PlaceTower();
-
+            indicator.GetComponent<TowerPlacer>().PlaceTower();
+            indicator.GetComponent<TowerPlacer>().MoveTransaction(true);
+            bool check = indicator.GetComponent<TowerPlacer>().CheckTransaction();
             yield return null;
             Assert.IsTrue(check);
             Assert.IsNotNull(GameObject.Find("BaseTower(Clone)"));


### PR DESCRIPTION
**Description:** added a cost for the movement of tower

**Issue:** Fixes #78 

**Steps to test:**
1. Play the main scene to test.

**Outstanding:**
1. Added the tower type script to all the towers.
1. The movement cost now depends on the type of tower being moved
1. The movement initiates a dialog pop up as in case of upgrading towers
1. The placer is now destroyed after the entire process is completed.
1. Fixed some tests issues 
